### PR TITLE
add r-sig-mixed-models

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ We track the following archives (file an issue to get a new list added):
 ## `r-sig-finance`: Special interest group (SIC) on R in finance
 
 > A mailing list for discussing the use of R in finance.
+
+
+## `r-sig-mixed-models`: Special interest group (SIG) on R in finance
+
+> A mailing list for useRs and programmeRs interested in use and development of mixed effect (hierarchical/multilevel) models in R. While focused on the lme4 package, many other packages are also discussed here.
+

--- a/update_archives.R
+++ b/update_archives.R
@@ -13,6 +13,8 @@ mailing_lists = list(
   c(name = 'r-announce', current = format(today, '%Y')),
   c(name = 'r-sig-geo', current = format(today, '%Y-%B.txt')),
   c(name = 'r-sig-finance',
+    current = with(today, sprintf('%dq%d.txt', year + 1900L, mon %/% 3L + 1L))),
+  c(name = 'r-sig-mixed-models',
     current = with(today, sprintf('%dq%d.txt', year + 1900L, mon %/% 3L + 1L)))
 )
 for (ii in seq_along(mailing_lists)) {


### PR DESCRIPTION
seemed to work fine locally ...

is there a reason that the README uses "SIC" instead of "SIG" when labelling the (other) special interest groups? (also, I think S-PLUS is supposed to be all-caps https://en.wikipedia.org/wiki/S-PLUS, although it hardly matters any more ...)
